### PR TITLE
typo: replace windows to mac in `patch_mac`

### DIFF
--- a/3.make_release.py
+++ b/3.make_release.py
@@ -290,7 +290,7 @@ def patch_windows(file_name):
 
 def patch_mac(file_name):
     if not file_name.endswith('.zip'):
-        print('windows 文件名有问题')
+        print('mac 文件名有问题')
         exit()
 
     file_path = TRANS_RELEASE_FOLDER + file_name


### PR DESCRIPTION
he error message is misleading because it mentions 'windows' in a function that is intended for patching Mac files. This could lead to confusion about the error's context.